### PR TITLE
fix: do not embed vega map vis on safari

### DIFF
--- a/pages/index.html
+++ b/pages/index.html
@@ -198,6 +198,9 @@ permalink: /index.html
     };
 
     window.onload = () => {
+        const isSafari = /^((?!chrome|android).)*safari/i.test(navigator.userAgent);
+        if(isSafari) return;
+        
         vegaEmbed(
             `#continents-map-horizontal`,
             horizontalPlotUrl,

--- a/pages/index.html
+++ b/pages/index.html
@@ -198,6 +198,7 @@ permalink: /index.html
     };
 
     window.onload = () => {
+        // see https://stackoverflow.com/a/23522755
         const isSafari = /^((?!chrome|android).)*safari/i.test(navigator.userAgent);
         if(isSafari) return;
         


### PR DESCRIPTION
I am confronting a crash again on Safai (#15). Maybe I did not thoroughly check if the previous PR (#16) fixes the issue.

I can confirm that there is something to do with **_map_** visualizations on the `index` page. Other pages that contain other types of vega visualizations work fine on Safari, and when I remove the map visualization, the `index` page does not crash anymore.

I did not find a way to fix this. Perhaps, we want to remove map visualizations on Safari for now since we do not want to leave the page crashes for a longer time. We can revert this change back once this Safari issue is fixed.

I've deployed the website based on this change, so you can test the website, http://covidclinical.net